### PR TITLE
Add GitHub Actions workflow for Ansible syntax checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  ansible-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Ansible
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible-core
+
+      - name: Validate playbook syntax
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          checked=0
+          for playbook in playbooks/*.yml playbooks/*.yaml; do
+            [ -f "$playbook" ] || continue
+            checked=1
+            if [ -s "$playbook" ]; then
+              echo "Checking $playbook"
+              ansible-playbook --syntax-check -i localhost, "$playbook"
+            else
+              echo "Skipping empty playbook $playbook"
+            fi
+          done
+          if [ "$checked" -eq 0 ]; then
+            echo "No playbooks found to validate."
+          fi


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs on pushes and pull requests to main
- install ansible-core in CI and execute syntax checks for all playbooks, skipping empty files

## Testing
- set -euo pipefail; shopt -s nullglob; checked=0; for playbook in playbooks/*.yml playbooks/*.yaml; do [ -f "$playbook" ] || continue; checked=1; if [ -s "$playbook" ]; then echo "Checking $playbook"; ansible-playbook --syntax-check -i localhost, "$playbook"; else echo "Skipping empty playbook $playbook"; fi; done; if [ "$checked" -eq 0 ]; then echo "No playbooks found to validate."; fi

------
https://chatgpt.com/codex/tasks/task_e_68d3d776b58c8333b013991eccb6ea4f