### PR TITLE
Add runner script test to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,13 @@ jobs:
           if [ "$checked" -eq 0 ]; then
             echo "No playbooks found to validate."
           fi
+
+      - name: Test runner script
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./runner.sh help > /tmp/runner-help.txt
+          grep -q "Usage:" /tmp/runner-help.txt
+          ./runner.sh list > /tmp/runner-list.txt
+          grep -q "Verfügbare Playbooks" /tmp/runner-list.txt
+          ./runner.sh run site --syntax-check


### PR DESCRIPTION
## Summary
- extend the CI workflow to run the runner.sh helper commands
- verify the help and list output and run the site playbook in syntax-check mode

## Testing
- ./runner.sh help

------
https://chatgpt.com/codex/tasks/task_e_68d3d8d838e0833391b187b6c65f7168