### PR TITLE
Avoid auto appending vault id in runner

### DIFF
--- a/runner.sh
+++ b/runner.sh
@@ -87,10 +87,6 @@ append_vault_arguments() {
     _cmd_ref+=("--vault-id" "$ANSIBLE_VAULT_ID")
   elif [[ -n "${ANSIBLE_VAULT_PASSWORD_FILE:-}" ]]; then
     _cmd_ref+=("--vault-password-file" "$ANSIBLE_VAULT_PASSWORD_FILE")
-  elif [[ -f "$DEFAULT_VAULT_PASSWORD_FILE" ]]; then
-    _cmd_ref+=("--vault-password-file" "$DEFAULT_VAULT_PASSWORD_FILE")
-  elif [[ -f "$DEFAULT_VAULT_ID_FILE" ]]; then
-    _cmd_ref+=("--vault-id" "$DEFAULT_VAULT_ID_FILE")
   fi
 }
 


### PR DESCRIPTION
## Summary
- ensure the runner does not append a default --vault-id argument unless environment variables request it

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3e9471034833383e76156afd5426b